### PR TITLE
Prefer "merge" as the operation name over "update".

### DIFF
--- a/src/main/java/com/github/danieladams456/statusvoter/StatusVoter.java
+++ b/src/main/java/com/github/danieladams456/statusvoter/StatusVoter.java
@@ -12,12 +12,12 @@ public class StatusVoter {
     }
 
     /**
-     * Updates the current status classification if the incoming classification
-     * has a higher score than the existing classification.
+     * Merges the incoming classification with the existing status classification.
+     * The status classification with the higher score is retained.
      *
      * @param newClassification the new, incoming classification to merge with the existing classification
      */
-    public void update(StatusClassification newClassification) {
+    public void merge(StatusClassification newClassification) {
         if (null == newClassification) {
             classification = StatusClassification.UNRECOGNIZED_STATUS_ERROR;
         } else if (newClassification.getScore() > classification.getScore()) {
@@ -33,11 +33,11 @@ public class StatusVoter {
      *
      * @param newClassification the new, incoming classification to merge with the existing classification
      */
-    public void update(String newClassification) {
+    public void merge(String newClassification) {
         try {
-            update(StatusClassification.valueOf(newClassification));
+            merge(StatusClassification.valueOf(newClassification));
         } catch (IllegalArgumentException | NullPointerException e) {
-            update(StatusClassification.UNRECOGNIZED_STATUS_ERROR);
+            merge(StatusClassification.UNRECOGNIZED_STATUS_ERROR);
         }
     }
 

--- a/src/test/java/com/github/danieladams456/statusvoter/InputValidationTest.java
+++ b/src/test/java/com/github/danieladams456/statusvoter/InputValidationTest.java
@@ -14,7 +14,7 @@ public class InputValidationTest {
     @ValueSource(strings = {"invalid", "UNRECOGNIZED_STATUS_ERROR"})
     void stringUpdateMethod(String invalidStatus) {
         StatusVoter voter = new StatusVoter();
-        voter.update(invalidStatus);
+        voter.merge(invalidStatus);
         assertThat(voter.getClassification()).isEqualTo(StatusClassification.UNRECOGNIZED_STATUS_ERROR);
     }
 
@@ -23,7 +23,7 @@ public class InputValidationTest {
     @EnumSource(names = "UNRECOGNIZED_STATUS_ERROR")
     void enumUpdateMethod(StatusClassification invalidStatus) {
         StatusVoter voter = new StatusVoter();
-        voter.update(invalidStatus);
+        voter.merge(invalidStatus);
         assertThat(voter.getClassification()).isEqualTo(StatusClassification.UNRECOGNIZED_STATUS_ERROR);
     }
 }

--- a/src/test/java/com/github/danieladams456/statusvoter/SerializationTest.java
+++ b/src/test/java/com/github/danieladams456/statusvoter/SerializationTest.java
@@ -26,7 +26,7 @@ public class SerializationTest {
     void testSerializeRecord() throws IOException {
         TestRecord record = new TestRecord("test1", "test2", new StatusVoter());
         // test some variety in status
-        record.voter.update(StatusClassification.CUSTOMER_DATA_VALIDATION_ERROR);
+        record.voter.merge(StatusClassification.CUSTOMER_DATA_VALIDATION_ERROR);
         ObjectMapper mapper = new ObjectMapper();
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         mapper.writeValue(outputStream, record);

--- a/src/test/java/com/github/danieladams456/statusvoter/StateTransitionTest.java
+++ b/src/test/java/com/github/danieladams456/statusvoter/StateTransitionTest.java
@@ -36,9 +36,9 @@ public class StateTransitionTest {
             for (int j = 0; j < statusesInOrder.size(); j++)
                 for (int k = 0; k < statusesInOrder.size(); k++) {
                     StatusVoter voter = new StatusVoter();
-                    voter.update(statusesInOrder.get(i));
-                    voter.update(statusesInOrder.get(j));
-                    voter.update(statusesInOrder.get(k));
+                    voter.merge(statusesInOrder.get(i));
+                    voter.merge(statusesInOrder.get(j));
+                    voter.merge(statusesInOrder.get(k));
 
                     var maxIndex = Math.max(Math.max(i, j), k);
                     var expectedClassification = statusesInOrder.get(maxIndex);


### PR DESCRIPTION
"Merge" more accurately conveys that the existing status might be retained if it has a higher score than the new classification.