### PR TITLE
Merge Status Concurrency Fix

### DIFF
--- a/src/main/java/com/github/danieladams456/statusvoter/StatusVoter.java
+++ b/src/main/java/com/github/danieladams456/statusvoter/StatusVoter.java
@@ -14,10 +14,14 @@ public class StatusVoter {
     /**
      * Merges the incoming classification with the existing status classification.
      * The status classification with the higher score is retained.
+     * <p>
+     * This method is marked as synchronized to avoid concurrency bugs.
+     * It is not a huge penalty to mark the whole method as such since it
+     * is fast in comparison to the work this status is tracking.
      *
      * @param newClassification the new, incoming classification to merge with the existing classification
      */
-    public void merge(StatusClassification newClassification) {
+    public synchronized void merge(StatusClassification newClassification) {
         // null value is reset to a legitimate non-null value
         if (null == newClassification) {
             newClassification = StatusClassification.INTERNAL_STATUS_MERGE_ERROR;

--- a/src/test/java/com/github/danieladams456/statusvoter/ConcurrencyTest.java
+++ b/src/test/java/com/github/danieladams456/statusvoter/ConcurrencyTest.java
@@ -1,0 +1,58 @@
+package com.github.danieladams456.statusvoter;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import static com.github.danieladams456.statusvoter.TestData.STATUSES_IN_ORDER;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ConcurrencyTest {
+    /**
+     * This test checks for atomic compare-and-set merges.
+     * Set each status on a separate thread, and always expect the final result to be the most severe.
+     */
+    @Test
+    void multipleConcurrentUpdates() throws InterruptedException {
+        final int testIterations = 10_000;
+        int failureCount = 0;  // should not need AtomicInteger
+
+        for (int i = 0; i < testIterations; i++) {
+            try (ExecutorService executor = Executors.newFixedThreadPool(STATUSES_IN_ORDER.size())) {
+                CountDownLatch startLatch = new CountDownLatch(1);
+                CountDownLatch doneLatch = new CountDownLatch(STATUSES_IN_ORDER.size());
+                StatusVoter voter = new StatusVoter();
+
+                for (StatusClassification statusClassification : STATUSES_IN_ORDER) {
+                    executor.submit(() -> {
+                        try {
+                            startLatch.await();
+                            Thread.sleep(1);
+                            voter.merge(statusClassification);
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                        } finally {
+                            doneLatch.countDown();
+                        }
+                    });
+                }
+
+                // single countDown() will unblock
+                startLatch.countDown();
+                // wait until all threads have completed their operations, then shut down thread pool.
+                doneLatch.await();
+                executor.shutdown();
+                assertThat(executor.awaitTermination(100, TimeUnit.MILLISECONDS)).isTrue();
+
+                // result should always be the most critical status
+                if (voter.getClassification() != StatusClassification.INTERNAL_ERROR) {
+                    failureCount++;
+                }
+            }
+        }
+        assertThat(failureCount).isEqualTo(0);
+    }
+}

--- a/src/test/java/com/github/danieladams456/statusvoter/StateTransitionTest.java
+++ b/src/test/java/com/github/danieladams456/statusvoter/StateTransitionTest.java
@@ -5,20 +5,10 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
 
-import java.util.List;
-
+import static com.github.danieladams456.statusvoter.TestData.STATUSES_IN_ORDER;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class StateTransitionTest {
-    private static final List<StatusClassification> statusesInOrder = List.of(
-            StatusClassification.INITIAL,
-            StatusClassification.SUCCESS,
-            StatusClassification.UNCLEAR_ATTRIBUTION_ERROR,
-            StatusClassification.CUSTOMER_DATA_ERROR,
-            StatusClassification.CUSTOMER_DATA_VALIDATION_ERROR,
-            StatusClassification.INTERNAL_STATUS_MERGE_ERROR,
-            StatusClassification.INTERNAL_ERROR
-    );
 
     @Test
     void testStatusInit() {
@@ -35,16 +25,16 @@ public class StateTransitionTest {
      */
     @Test
     void testStatusOnlyMovesUp() {
-        for (int i = 0; i < statusesInOrder.size(); i++)
-            for (int j = 0; j < statusesInOrder.size(); j++)
-                for (int k = 0; k < statusesInOrder.size(); k++) {
+        for (int i = 0; i < STATUSES_IN_ORDER.size(); i++)
+            for (int j = 0; j < STATUSES_IN_ORDER.size(); j++)
+                for (int k = 0; k < STATUSES_IN_ORDER.size(); k++) {
                     StatusVoter voter = new StatusVoter();
-                    voter.merge(statusesInOrder.get(i));
-                    voter.merge(statusesInOrder.get(j));
-                    voter.merge(statusesInOrder.get(k));
+                    voter.merge(STATUSES_IN_ORDER.get(i));
+                    voter.merge(STATUSES_IN_ORDER.get(j));
+                    voter.merge(STATUSES_IN_ORDER.get(k));
 
                     var maxIndex = Math.max(Math.max(i, j), k);
-                    var expectedClassification = statusesInOrder.get(maxIndex);
+                    var expectedClassification = STATUSES_IN_ORDER.get(maxIndex);
                     assertThat(voter.getClassification()).isEqualTo(expectedClassification);
                     assertThat(voter).hasToString(expectedClassification.name());
                 }

--- a/src/test/java/com/github/danieladams456/statusvoter/TestData.java
+++ b/src/test/java/com/github/danieladams456/statusvoter/TestData.java
@@ -1,0 +1,15 @@
+package com.github.danieladams456.statusvoter;
+
+import java.util.List;
+
+public class TestData {
+    static final List<StatusClassification> STATUSES_IN_ORDER = List.of(
+            StatusClassification.INITIAL,
+            StatusClassification.SUCCESS,
+            StatusClassification.UNCLEAR_ATTRIBUTION_ERROR,
+            StatusClassification.CUSTOMER_DATA_ERROR,
+            StatusClassification.CUSTOMER_DATA_VALIDATION_ERROR,
+            StatusClassification.INTERNAL_STATUS_MERGE_ERROR,
+            StatusClassification.INTERNAL_ERROR
+    );
+}


### PR DESCRIPTION
## Bug
I realized that the two compare-and-set operations in the status merge method are not thread safe.

I had originally assumed that all status bookkeeping would happen on the main thread (or virtual thread.)  In the non-reactive servlet model, each incoming request gets its own thread.  Even if you fork off that with a CompletableFuture or other mechanism, you would be fine as long as you updated the status from the calling thread after the result returned.

The issue arises if the `StatusVoter` instance is passed into the spawned thread.  Now, multiple threads can attempt to concurrently modify the status.
1. Thread `A` reads that new status `CUSTOMER_DATA_ERROR` has a higher score than current status `INITIAL`.
2.  Thread `B` reads that new status `INTERNAL_ERROR` has a higher score than current status `INITIAL`.
3. Thread `B` sets current status to `INTERNAL_ERROR`.
4. Thread `A` sets current status to `CUSTOMER_DATA_ERROR`.

## Proof
The invariant of "status always moves from lower score to higher score/severity" has been broken.  We can prove it with the concurrency test.  Observations:
1. `10_000` iterations gave over 10x the failures of `1_000`.  Maybe the OS was more likely to preempt the java process after longer continuous high CPU?  Solely conjecture.  However, the margins of getting the correct result were better on the higher number, so I kept it there despite making tests slower.
2. The 1 millisecond thread sleep also helped, so kept that in.

## Fix
The most straightforward locking approach is to simply use a [synchronized method](https://docs.oracle.com/javase/tutorial/essential/concurrency/syncmeth.html).  Very clean code and fixes the concurrency test.

As I mention in the comments:
> It is not a huge penalty to mark the whole method as such since it is fast in comparison to the work this status is tracking.

Review with: @rgallardo-netflix
Note: rebased so commit timestamps are messed up.